### PR TITLE
feat: create addSnippet function to submit new practice snippet to Airtable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import './App.css';
 import HomePage from './pages/HomePage';
@@ -7,6 +7,88 @@ import NavBar from './shared/NavBar';
 import PracticeForm from './pages/PracticeForm';
 
 function App() {
+  const [practiceSnippet, setPracticeSnippet] = useState([]);
+  const [goal, setGoal] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const url = `https://api.airtable.com/v0/${import.meta.env.app1eig7m0uO4LtUt}/${import.meta.env.PracticePlan}`;
+  const token = `Bearer ${import.meta.env.patPp2fUtGYYH2NEq.2df470a08153e254b540489a9932a27fa3f24dcc99132dd27fce39d9809196c2}`;
+
+  function handleGoalChange(e) {
+    setGoal(e.target.value);
+    // console.log(e.target.value);
+  }
+//1. function for adding a goal/practice snippet
+
+  const addSnippet = async (newSnippet) => {
+    const payload = {
+      records: [
+        {
+          fields: {
+            // type:
+            // musicalKey:
+            // metronome:
+            // timeSpent:
+            goal: newSnippet.goal,
+            isCompleted: newSnippet.isCompleted,
+          },
+        },
+      ],
+    };
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Authorization': token,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+};
+
+try {
+  setIsSaving(true);
+  const resp = await fetch(url, options);
+
+  if(!resp.ok) {
+    throw new Error('Failed to add new practice snippet');
+  }
+
+  const { records } = await resp.json();
+  const savedSnippet = {
+    id: records[0].id,
+    ...records[0].fields,
+  };
+
+  // if (!records[0].fields.isCompleted) {
+  //   savedSnippet.isCompleted = false;
+  // }
+
+  setPracticeSnippet([...practiceSnippet, savedSnippet]);
+} catch (error) {
+  console.log(error);
+  setErrorMessage(error.message);
+} finally {
+  setIsSaving(false);
+}
+  
+};
+
+// 2. useEffect for fetching goals/practice snippets from Airtable
+// useEffect(() => {
+//   const fetchGoals = async (newGoal) => {
+//     setIsLoading(true);
+//     const options = {
+//       method: 'GET',
+//       headers: {
+//         'Authorization': token,
+//       }
+//     }
+//   };
+//   fetchGoals();
+// }, [])
+
   return (
     <>
       {' '}

--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -1,21 +1,36 @@
 // The id for PracticePlan is tbl3FisNmoYOiIucq.
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import App from './App';
 
 function PracticeForm() {
-  const [goal, setGoal] = useState('');
+  //   async function handleSubmit(e) {
+  //     e.preventDefault();
+  //     const payload = {
+  //       records: [
+  //         {
+  //         fields: {
+  //         goal: goal,
+  //         isCompleted: false,
+  //         },
+  //       },
+  //       ],
+  //     };
 
-  function handleGoalChange(e) {
-    setGoal(e.target.value);
-    console.log(e.target.value); //for testing
-  }
+  //     const options = {
+  //       method: 'GET',
+  //       headers: {
+  //         'Authorization: token',
+  //       },
+  //       body: JSON.stringify(payload),
+  //     };
 
-  function handleSubmit(e) {
-    //user hits submit, run this function
-    e.preventDefault(); //prevents page from reloading upon form submission
-    console.log('Goal Submitted:', goal); //for testing
-    setGoal(''); //clear input field after submission
-  }
+  //     try {
+  //       })
+  //     }
+  //     // console.log('Goal Submitted:', goal);
+  //     setGoal('');
+  //   }
 
   return (
     <form onSubmit={handleSubmit}>


### PR DESCRIPTION
- Created an addSnippet function to send a practice snippet to Airtable using POST request
- Basic error handling and loading state management added
- Adds new snippet to local practiceSnippet array state after successful submission
- A practice snippet will contain a goal, practice type, musical key, metronome marking, and time spent fields
- Only the "goal" field is included for now for functionality testing as the remaining fields will be added later