### PR TITLE
feat: fetch practice snippet from Airtable with useEffect

### DIFF
--- a/src/features/SnippetList.jsx
+++ b/src/features/SnippetList.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function SnippetList() {
+  return <></>;
+}
+
+export default SnippetList;
+
+//Essentially an array of snippets
+// A snippet contains all practice information and displays it


### PR DESCRIPTION
This PR adds the ability to fetch all practice snippets from Airtable when the PracticeForm component mounts. Snippets are stored in state and displayed below the form.

- Added useEffect to fetch all practice snippets from Airtable API
- Created state to store all snippets
- Rendered a list of snippets below the practice form
- Added loading and error states