### PR TITLE
feat: integrate SnippetEditRow for inline editing of practice snippets

### DIFF
--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -192,6 +192,12 @@ function PracticeForm() {
     }
   }
 
+  function handleSaveEdit(id) {
+    updateSnippet({ id, ...editFields });
+    setEditId(null);
+    setEditFields({});
+  }
+
   // 4. Complete a practice snippet
   async function completeSnippet(id) {
     const options = {
@@ -308,17 +314,47 @@ function PracticeForm() {
           .filter((snippet) => !snippet.isCompleted)
           .map((snippet) => (
             <li key={snippet.id}>
-              <input
-                type="checkbox"
-                className="checkboxItem"
-                checked={false}
-                onChange={() => completeSnippet(snippet.id)}
-                disabled={isSaving}
-              />
-              {snippet.practiceType && <span> {snippet.practiceType} | </span>}
-              {snippet.goal}
-              {snippet.metronome && <span> | {snippet.metronome} BPM</span>}
-              {snippet.timeSpent && <span> | {snippet.timeSpent} Minutes</span>}
+              {editId === snippet.id ? (
+                <SnippetEditRow
+                  editFields={editFields}
+                  setEditFields={setEditFields}
+                  onSave={() => handleSaveEdit(snippet.id)}
+                  onCancel={() => setEditId(null)}
+                  isSaving={isSaving}
+                />
+              ) : (
+                <>
+                  <input
+                    type="checkbox"
+                    className="checkboxItem"
+                    checked={false}
+                    onChange={() => completeSnippet(snippet.id)}
+                    disabled={isSaving}
+                  />
+                  {snippet.practiceType && (
+                    <span> {snippet.practiceType} | </span>
+                  )}
+                  {snippet.goal}
+                  {snippet.metronome && <span> | {snippet.metronome} BPM</span>}
+                  {snippet.timeSpent && (
+                    <span> | {snippet.timeSpent} Minutes</span>
+                  )}
+                  <button
+                    onClick={() => {
+                      setEditId(snippet.id);
+                      setEditFields({
+                        practiceType: snippet.practiceType || '',
+                        goal: snippet.goal || '',
+                        metronome: snippet.metronome || '',
+                        timeSpent: snippet.timeSpent || '',
+                      });
+                    }}
+                    className="editButton"
+                  >
+                    Edit
+                  </button>
+                </>
+              )}
             </li>
           ))}
       </ul>


### PR DESCRIPTION
This PR introduces inline editing for practice snippets using the SnippetEditRow component. Users can now click "Edit" on any practice snippet to update its practice type, goal, metronome, or time spent and update it in the list. All changes are saved to Airtable.

- Integrated the SnippetEditRow component into the PracticeForm
- Add state handling for switching between edit mode and view/normal mode
- Users can now edit all fields inline for any practice snippet
- Updates are sent to Airtable when edits are saved
- Users can cancel an edit and return the snippet to its previous state
