### PR TITLE
refactor: replace number inputs with NumberInput component in SnippetEditRow

### DIFF
--- a/src/features/SnippetEditRow.jsx
+++ b/src/features/SnippetEditRow.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import SnippetList from './SnippetList';
+import NumberInput from '../shared/NumberInput';
 
 function SnippetEditRow({
   editFields,
@@ -24,6 +26,7 @@ function SnippetEditRow({
         <option value="Repertoire & Songs">Repertoire & Songs</option>
         <option value="Other">Other</option>
       </select>
+
       <input
         type="text"
         value={editFields.goal}
@@ -32,26 +35,29 @@ function SnippetEditRow({
         placeholder="e.g., G Major Pentatonic"
         required
       />
-      <input
-        type="number"
+
+      <NumberInput
+        id="edit-metronome"
         value={editFields.metronome}
         onChange={(e) =>
           setEditFields({ ...editFields, metronome: e.target.value })
         }
         min={1}
         max={500}
-        className="metronomeEditSelect"
-        required
+        placeholder="e.g., 100"
       />
-      <input
-        type="number"
+
+      <NumberInput
+        id="edit-time-spent"
         value={editFields.timeSpent}
         onChange={(e) =>
           setEditFields({ ...editFields, timeSpent: e.target.value })
         }
-        className="timeSpentEditSelect"
-        required
+        min={1}
+        max={500}
+        placeholder="e.g., 30"
       />
+
       <button onClick={onSave} disabled={isSaving} className="saveEditButton">
         Save
       </button>

--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -272,7 +272,7 @@ function PracticeForm() {
           onChange={(e) => setMetronome(e.target.value)}
           min={1}
           max={500}
-          placeholder="e.g., 120"
+          placeholder="e.g., 100"
         />
         <br />
         <NumberInput
@@ -282,7 +282,7 @@ function PracticeForm() {
           onChange={(e) => setTimeSpent(e.target.value)}
           min={1}
           max={500}
-          placeholder="e.g., 20"
+          placeholder="e.g., 30"
         />
         <br />
         <button
@@ -324,8 +324,6 @@ export default PracticeForm;
 
 // Add a way for users to delete a snippet
 // debounce the input with useEffect or create Clean up call
-// Add a SnippetList.jsx
-// Add a NumberInput.jsx for metronome and timeSpent inputs
 
 //Break into components and meet requirements
 // Cache Result of API call so it doesn't call everytime

--- a/src/shared/NumberInput.jsx
+++ b/src/shared/NumberInput.jsx
@@ -12,7 +12,6 @@ function NumberInput({
   return (
     <>
       <label htmlFor={id}>{label}</label>
-      <br />
       <input
         type="number"
         id={id}


### PR DESCRIPTION
This PR refactors SnippetEditRow to use the shared NumberInput component for the metronome and time spent fields.

- Removes <input type="number" /> elements in edit row
- Uses NumberInput for inline edit fields
- Removes label from NumberInput for clean style in edit mode
- No change to functionality
