### PR TITLE
refactor: create GeneralButton component and refactor all generic buttons to use it

### DIFF
--- a/src/features/SnippetEditRow.jsx
+++ b/src/features/SnippetEditRow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SnippetList from './SnippetList';
 import NumberInput from '../shared/NumberInput';
+import GeneralButton from '../shared/GeneralButton';
 
 function SnippetEditRow({
   editFields,
@@ -58,16 +59,20 @@ function SnippetEditRow({
         placeholder="e.g., 30"
       />
 
-      <button onClick={onSave} disabled={isSaving} className="saveEditButton">
+      <GeneralButton
+        onClick={onSave}
+        disabled={isSaving}
+        className="saveEditButton"
+      >
         Save
-      </button>
-      <button
+      </GeneralButton>
+      <GeneralButton
         onClick={onCancel}
         disabled={isSaving}
         className="cancelEditButton"
       >
         Cancel
-      </button>
+      </GeneralButton>
     </>
   );
 }

--- a/src/features/SnippetList.jsx
+++ b/src/features/SnippetList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SnippetEditRow from './SnippetEditRow';
+import GeneralButton from '../shared/GeneralButton';
 
 function SnippetList({
   snippets,
@@ -43,7 +44,7 @@ function SnippetList({
                 {snippet.timeSpent && (
                   <span> | {snippet.timeSpent} Minutes</span>
                 )}
-                <button
+                <GeneralButton
                   onClick={() => {
                     setEditId(snippet.id);
                     setEditFields({
@@ -56,7 +57,7 @@ function SnippetList({
                   className="editButton"
                 >
                   Edit
-                </button>
+                </GeneralButton>
               </>
             )}
           </li>

--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import SnippetEditRow from '../features/SnippetEditRow';
 import SnippetList from '../features/SnippetList';
 import NumberInput from '../shared/NumberInput';
+import GeneralButton from '../shared/GeneralButton';
 
 function PracticeForm() {
   const [practiceType, setPracticeType] = useState('');
@@ -285,7 +286,7 @@ function PracticeForm() {
           placeholder="e.g., 30"
         />
         <br />
-        <button
+        <GeneralButton
           type="submit"
           disabled={
             practiceType === '' ||
@@ -296,7 +297,7 @@ function PracticeForm() {
           }
         >
           {isSaving ? 'Saving...' : 'Submit'}
-        </button>
+        </GeneralButton>
       </form>
 
       {isLoading && <div>Loading practice routine...</div>}
@@ -323,10 +324,13 @@ export default PracticeForm;
 // Add feedback to user behavior ("Please fill all fields to submit");
 
 // Add a way for users to delete a snippet
-// debounce the input with useEffect or create Clean up call
+
+// useEffect - debounce the input with useEffect, timeout/debounce, clean up?
+// useCallback - memoize one of the handlers?
 
 //Break into components and meet requirements
 // Cache Result of API call so it doesn't call everytime
 // Reuse Number fields
 // Style with flexbox
 // Add sorting for each of the 4 fields
+// Add a "No active practice snippets" message for empty list

--- a/src/shared/GeneralButton.jsx
+++ b/src/shared/GeneralButton.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function GeneralButton({ children, className = '', style = {}, ...props }) {
+  return (
+    <button className={className} style={style} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export default GeneralButton;


### PR DESCRIPTION
This PR introduces a new GeneralButton component to improve consistency of button elements throughout the app. All generic buttons (Submit, Edit, Save, and Cancel) have been refactored to use this component.

- Created GeneralButton.jsx in shared folder
- GeneralButton accepts all button props and children
- Refactored all generic button elements in PracticeForm.jsx, SnippetEditRow.jsx, and SnippetList.jsx to use GeneralButton
- No UI or functional changes made