### PR TITLE
feat: show empty list message when no active practice snippets remain

### DIFF
--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -19,6 +19,7 @@ function PracticeForm() {
 
   const url = `https://api.airtable.com/v0/${import.meta.env.VITE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?sort[0][field]=createdTime&sort[0][direction]=asc`;
   const token = `Bearer ${import.meta.env.VITE_PAT}`;
+  const activeSnippets = allSnippets.filter((snippet) => !snippet.isCompleted);
 
   useEffect(() => {
     //useEffect for auto-clear success message
@@ -246,13 +247,12 @@ function PracticeForm() {
       setIsSaving(false);
     }
   }
-
+  console.log('Snippets:', allSnippets, 'length', allSnippets.length);
   return (
     <>
       {successMessage && (
         <div className="success-message">{successMessage}</div>
       )}
-
       <form onSubmit={handleAddSnippet}>
         <label htmlFor="practiceType">Practice Type:</label>
         <br />
@@ -314,12 +314,14 @@ function PracticeForm() {
           {isSaving ? 'Saving...' : 'Submit'}
         </GeneralButton>
       </form>
-
       {isLoading && <div>Loading practice routine...</div>}
       {errorMessage && <div style={{ color: 'red' }}>{errorMessage}</div>}
 
+      {!isLoading && activeSnippets.length === 0 && !errorMessage && (
+        <div>Please use the form above to add a practice snippet!</div>
+      )}
       <SnippetList
-        snippets={allSnippets}
+        snippets={activeSnippets}
         editId={editId}
         editFields={editFields}
         setEditId={setEditId}


### PR DESCRIPTION
This PR displays an empty list message when there are no active or incomplete practice snippets in the UI. A completed practice snippet remains stored in Airtable.

- Added activeSnippets variable to filter out completed practice snippets from allSnippets
- The "Please use the form above to add a practice snippet!", message appears only if there are no active/incomplete snippets
- Keeps completed practice snippets in Airtable for future use/history