### PR TITLE
style: add active link styling to NavBar using isActive parameter

### DIFF
--- a/src/features/SnippetList.module.css
+++ b/src/features/SnippetList.module.css
@@ -1,6 +1,7 @@
 .snippetList {
   list-style-type: none;
   width: 100%;
+  padding: 0;
 }
 
 .snippetList li {

--- a/src/index.css
+++ b/src/index.css
@@ -14,13 +14,13 @@ a {
   font-weight: 500;
   color: #0dff5a;
   text-decoration: inherit;
-  transition:
-    background 0.1s,
-    color 0.1s;
 }
 
 a:hover {
   color: #09c043;
+  transition:
+    background 0.1s,
+    color 0.1s;
 }
 
 body {

--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -304,37 +304,36 @@ function PracticeForm() {
             {isSaving ? 'Saving...' : 'Submit'}
           </GeneralButton>
         </form>
-
-        {successMessage && (
-          <div className={styles.successMessage}>{successMessage}</div>
-        )}
-
-        {isLoading && (
-          <div className={styles.isLoadingMessage}>
-            Loading practice routine...
-          </div>
-        )}
-
-        {errorMessage && <div>{errorMessage}</div>}
-
-        {!isLoading && activeSnippets.length === 0 && !errorMessage && (
-          <div className={styles.emptyFormMessage}>
-            Please use the form above to add a practice snippet!
-          </div>
-        )}
-
-        <SnippetList
-          snippets={activeSnippets}
-          editId={editId}
-          editFields={editFields}
-          setEditId={setEditId}
-          setEditFields={setEditFields}
-          onSaveEdit={handleSaveEdit}
-          onCancelEdit={() => setEditId(null)}
-          onComplete={completeSnippet}
-          isSaving={isSaving}
-        />
       </div>
+      {successMessage && (
+        <div className={styles.successMessage}>{successMessage}</div>
+      )}
+
+      {isLoading && (
+        <div className={styles.isLoadingMessage}>
+          Loading practice routine...
+        </div>
+      )}
+
+      {errorMessage && <div>{errorMessage}</div>}
+
+      {!isLoading && activeSnippets.length === 0 && !errorMessage && (
+        <div className={styles.emptyFormMessage}>
+          Please use the form above to add a practice snippet!
+        </div>
+      )}
+
+      <SnippetList
+        snippets={activeSnippets}
+        editId={editId}
+        editFields={editFields}
+        setEditId={setEditId}
+        setEditFields={setEditFields}
+        onSaveEdit={handleSaveEdit}
+        onCancelEdit={() => setEditId(null)}
+        onComplete={completeSnippet}
+        isSaving={isSaving}
+      />
     </>
   );
 }

--- a/src/shared/NavBar.jsx
+++ b/src/shared/NavBar.jsx
@@ -6,10 +6,20 @@ function NavBar() {
   return (
     <nav className={styles.navBar}>
       <div className={styles.links}>
-        <NavLink to="/" className={styles.link}>
+        <NavLink
+          to="/"
+          className={({ isActive }) =>
+            isActive ? `${styles.link} ${styles.active}` : styles.link
+          }
+        >
           Home
         </NavLink>
-        <NavLink to="/practice-form" className={styles.link}>
+        <NavLink
+          to="/practice-form"
+          className={({ isActive }) =>
+            isActive ? `${styles.link} ${styles.active}` : styles.link
+          }
+        >
           Practice Form
         </NavLink>
       </div>

--- a/src/shared/NavBar.module.css
+++ b/src/shared/NavBar.module.css
@@ -18,3 +18,8 @@
 .link {
   font-size: 1.05em;
 }
+
+.active {
+  font-weight: 700;
+  text-decoration: underline;
+}


### PR DESCRIPTION
This PR updates the NavBar to differentiate between the currently active route's link and inactive route links using css modules and isActive parameter. Users can now see which page is currently selected.

- Utilized NavLink's className prop with the isActive parameter for styling
- Adds .active class to NavBar.module.css
- Applied a bold and underline style to the active link in the NavBar