### PR TITLE
feature: add Fender Silverface inspired light mode colors and custom vintage grill cloth background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,8 +5,8 @@
   font-family: 'Ubuntu', Arial, sans-serif;
   line-height: 1.75;
   font-weight: 400;
-  color: #ffffffde;
-  background-color: #242424;
+  color: var(--color-text);
+  background-color: var(--color-background);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -35,17 +35,26 @@ body {
   min-height: 100vh;
 }
 
-/* @media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: light) {
   :root {
-    color: #393939;
-    background-color: #ffffffde;
+    --color-background: #929292;
+    --color-text: #181818;
+    --color-gold: #d8dbde;
+    --color-accent-gold: #50b9c7;
+    --color-red: #0aa7cf;
+    --color-accent-red: #07899a;
+    --color-success: #09c043;
+    --color-accent-green: #068e31;
+    --color-link: #50b9c7;
+    --color-snippet: #d8dbde;
+    --color-snippet-hover: #ced0d2;
+    --color-button-background: #0aa7cf;
+
+    background-image:
+      linear-gradient(black 0.1px, transparent 0.3px),
+      linear-gradient(to right, #0aa7cf 0.75px, transparent 0.5px);
+    background-size: 40px 20px;
+    background-color: #869696;
+    font-weight: 500;
   }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    color: #0dff5a;
-    font-weight: 600;
-    background-color: #393939;
-  }
-} */
+}


### PR DESCRIPTION
This PR introduces a Fender Silverface-inspired light mode theme to the app, giving it a music gear inspired look and feel. The update enhances visual appeal with a new color pallette for light mode while keeping dark mode unchanged.

- Updated the light mode color palette to mimic a vintage Fender Silverface amplifier (silver, blue, and black)
- Added a linear-gradient background pattern to replicate the amp's iconic grill cloth
- Increased font weight for better readability
- Applied all changes inside @media (prefers-color-scheme: light) to target only light mode
- Leave dark mode untouched for users who prefer dark mode